### PR TITLE
✨ allow custom file naming for add_records_to_dataset

### DIFF
--- a/gcpde/gcs.py
+++ b/gcpde/gcs.py
@@ -74,7 +74,7 @@ class BuildFileNameProtocol(Protocol):
         Returns:
             str: The generated file name
         """
-        ...
+        ...  # pragma: no cover
 
 
 def _build_file_name(dataset: str, datetime_partition: DateTimePartitions) -> str:

--- a/gcpde/gcs.py
+++ b/gcpde/gcs.py
@@ -170,8 +170,10 @@ def add_records_to_dataset(
     file_path = _build_file_path(
         dataset=dataset, version=version, datetime_partition=datetime_partition
     )
-    file_name = (build_file_name or _build_file_name)(
-        dataset=dataset, datetime_partition=datetime_partition
+    file_name = (
+        build_file_name()
+        if build_file_name
+        else _build_file_name(dataset=dataset, datetime_partition=datetime_partition)
     )
 
     jsonl_file_str = "\n".join(json_str_records)

--- a/gcpde/gcs.py
+++ b/gcpde/gcs.py
@@ -4,7 +4,7 @@ import asyncio
 import io
 import json
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 import tenacity
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout
@@ -62,7 +62,23 @@ def _build_file_path(
         f"month={datetime_partition.month}/"
         f"day={datetime_partition.day}"
     )
-    return f"{dataset}/{partitions_path}/{dataset}__{datetime_partition}.jsonl"
+    return f"{dataset}/{partitions_path}/"
+
+
+class BuildFileNameProtocol(Protocol):
+    """Protocol for building file names."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> str:
+        """Build a file name with any number of arguments.
+
+        Returns:
+            str: The generated file name
+        """
+        ...
+
+
+def _build_file_name(dataset: str, datetime_partition: DateTimePartitions) -> str:
+    return f"{dataset}__{datetime_partition}.jsonl"
 
 
 def _get_gcs_client(
@@ -122,6 +138,7 @@ def add_records_to_dataset(
     datetime_partition: Optional[DateTimePartitions] = None,
     json_key: Optional[Dict[str, str]] = None,
     client: Optional[StorageClient] = None,
+    build_file_name: Optional[BuildFileNameProtocol] = None,
 ) -> None:
     """Add a jsonl file to gcs using our file path conventions.
 
@@ -133,6 +150,8 @@ def add_records_to_dataset(
         bucket_name: temporal partitioning for the object path.
         json_key: json key with gcp credentials.
         client: google storage client to use for connecting to the API.
+        build_file_name: optional callable that generates the file name.
+            If not provided, defaults to internal _build_file_name method.
 
     """
     _check_auth_args(json_key=json_key, client=client)
@@ -148,15 +167,19 @@ def add_records_to_dataset(
         year=ts_now.year, month=ts_now.month, day=ts_now.day, hour=ts_now.hour
     )
 
-    file_name = _build_file_path(
+    file_path = _build_file_path(
         dataset=dataset, version=version, datetime_partition=datetime_partition
     )
+    file_name = (build_file_name or _build_file_name)(
+        dataset=dataset, datetime_partition=datetime_partition
+    )
+
     jsonl_file_str = "\n".join(json_str_records)
 
     _upload_file(
         content=jsonl_file_str,
         bucket_name=bucket_name,
-        file_name=file_name,
+        file_name=file_path + file_name,
         client=client or _get_gcs_client(json_key=json_key or {}),
     )
     logger.info(f"File {file_name} created successfully!")

--- a/tests/unit/test_gcs.py
+++ b/tests/unit/test_gcs.py
@@ -60,21 +60,21 @@ def test_add_records_to_dataset(mock_upload_file: mock.Mock):
         client=mock_client,
     )
 
+
 @time_machine.travel(
     destination=datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc), tick=False
 )
 @mock.patch("gcpde.gcs._upload_file", autospec=True)
-def test_add_records_to_dataset_with_custom_filename_builder(mock_upload_file: mock.Mock):
+def test_add_records_to_dataset_with_custom_filename_builder(
+    mock_upload_file: mock.Mock,
+):
     # arrange
     mock_client = mock.Mock(spec_set=Client)
-    def custom_filename_builder(
-        id: str
-    ) -> str:
+
+    def custom_filename_builder(id: str) -> str:
         return f"custom_{id}.jsonl"
-    json_str_records = [
-        '{"id": "1"}',
-        '{"id": "2"}'
-    ]
+
+    json_str_records = ['{"id": "1"}', '{"id": "2"}']
     # act
     for record in json_str_records:
         gcs.add_records_to_dataset(
@@ -89,20 +89,23 @@ def test_add_records_to_dataset_with_custom_filename_builder(mock_upload_file: m
         )
 
     # assert
-    mock_upload_file.assert_has_calls([
-        mock.call(
-            content='{"id": "1"}',
-            bucket_name="my-bucket",
-            file_name="dataset/version=1/year=2022/month=1/day=1/custom_1.jsonl",
-            client=mock_client,
-        ),
-        mock.call(
-            content='{"id": "2"}',
-            bucket_name="my-bucket",
-            file_name="dataset/version=1/year=2022/month=1/day=1/custom_2.jsonl",
-            client=mock_client,
-        ),
-    ])
+    mock_upload_file.assert_has_calls(
+        [
+            mock.call(
+                content='{"id": "1"}',
+                bucket_name="my-bucket",
+                file_name="dataset/version=1/year=2022/month=1/day=1/custom_1.jsonl",
+                client=mock_client,
+            ),
+            mock.call(
+                content='{"id": "2"}',
+                bucket_name="my-bucket",
+                file_name="dataset/version=1/year=2022/month=1/day=1/custom_2.jsonl",
+                client=mock_client,
+            ),
+        ]
+    )
+
 
 @mock.patch(
     "google.oauth2.service_account.Credentials.from_service_account_info", autospec=True

--- a/tests/unit/test_gcs.py
+++ b/tests/unit/test_gcs.py
@@ -42,6 +42,11 @@ def test_add_records_to_dataset(mock_upload_file: mock.Mock):
     # arrange
     mock_client = mock.Mock(spec_set=Client)
 
+    def custom_filename_builder(
+        dataset: str, datetime_partition: gcs.DateTimePartitions
+    ) -> str:
+        return f"custom_{dataset}_{datetime_partition.year}.jsonl"
+
     # act
     gcs.add_records_to_dataset(
         bucket_name="my-bucket",
@@ -49,14 +54,14 @@ def test_add_records_to_dataset(mock_upload_file: mock.Mock):
         dataset="dataset",
         version="1",
         client=mock_client,
+        build_file_name=custom_filename_builder,
     )
 
     # assert
     mock_upload_file.assert_called_with(
         content='{"id": "1"}\n{"id": "2"}',
         bucket_name="my-bucket",
-        file_name="dataset/version=1/year=2022/month=1/day=1/"
-        "dataset__2022-01-01T00:00.jsonl",
+        file_name="dataset/version=1/year=2022/month=1/day=1/custom_dataset_2022.jsonl",
         client=mock_client,
     )
 

--- a/tests/unit/test_gcs.py
+++ b/tests/unit/test_gcs.py
@@ -42,11 +42,6 @@ def test_add_records_to_dataset(mock_upload_file: mock.Mock):
     # arrange
     mock_client = mock.Mock(spec_set=Client)
 
-    def custom_filename_builder(
-        dataset: str, datetime_partition: gcs.DateTimePartitions
-    ) -> str:
-        return f"custom_{dataset}_{datetime_partition.year}.jsonl"
-
     # act
     gcs.add_records_to_dataset(
         bucket_name="my-bucket",
@@ -54,14 +49,13 @@ def test_add_records_to_dataset(mock_upload_file: mock.Mock):
         dataset="dataset",
         version="1",
         client=mock_client,
-        build_file_name=custom_filename_builder,
     )
 
     # assert
     mock_upload_file.assert_called_with(
         content='{"id": "1"}\n{"id": "2"}',
         bucket_name="my-bucket",
-        file_name="dataset/version=1/year=2022/month=1/day=1/custom_dataset_2022.jsonl",
+        file_name="dataset/version=1/year=2022/month=1/day=1/dataset__2022-01-01T00:00.jsonl",
         client=mock_client,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "gcpde"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bigquery-schema-generator" },


### PR DESCRIPTION
# Add BuildFileNameProtocol for Flexible File Name Generation

## Changes
- Added `BuildFileNameProtocol` to allow custom file name generation strategies in `add_records_to_dataset`
- Updated `add_records_to_dataset` to accept an optional `build_file_name` parameter
- Added test coverage for custom file name builders
- Added `# pragma: no cover` to Protocol definition as it's used for type checking only

## Details
The new `BuildFileNameProtocol` allows users to provide custom file name generation logic when adding records to GCS. This makes the file naming system more flexible while maintaining type safety through Python's Protocol system.