### PR TITLE
✨ Add upsert from records

### DIFF
--- a/gcpde/bq.py
+++ b/gcpde/bq.py
@@ -55,12 +55,21 @@ class BigQueryClient:
             True if the table exists, False otherwise.
 
         """
-        table_ref = self._create_table_reference(dataset, table)
         try:
-            self.client.get_table(table=table_ref)
+            self.get_table(dataset, table)
             return True
         except NotFound:
             return False
+
+    def get_table(self, dataset: str, table: str) -> bigquery.Table:
+        """Get a table from bigquery.
+
+        Args:
+            dataset: dataset name.
+            table: table name.
+        """
+        table_ref = self._create_table_reference(dataset, table)
+        return self.client.get_table(table=table_ref)
 
     def create_table(
         self,
@@ -169,6 +178,28 @@ class BigQueryClient:
 
 class BigQueryClientException(Exception):
     """Base exception for connection or command errors."""
+
+
+class BigQuerySchemaMismatchException(Exception):
+    """Exception for schema mismatch."""
+
+    def __init__(
+        self,
+        message: str,
+        source_schema: list[bigquery.SchemaField],
+        target_schema: list[bigquery.SchemaField],
+    ):
+        super().__init__(message)
+        self.message = message
+        self.source_schema = source_schema
+        self.target_schema = target_schema
+
+    def __str__(self):
+        return (
+            f"{self.message}\n"
+            f"Source schema: {self.source_schema}\n"
+            f"Target schema: {self.target_schema}"
+        )
 
 
 def delete_table(
@@ -341,6 +372,93 @@ def create_or_replace_table_as(
     logger.info(f"Running `{command_sql}`...")
     client.run_command(command_sql=command_sql)
     logger.info("Command executed!")
+
+
+def upsert_table_from_records(
+    dataset: str,
+    table: str,
+    records: ListJsonType,
+    key_field: str,
+    json_key: dict[str, str] | None = None,
+    insert_chunk_size: int | None = None,
+    client: BigQueryClient | None = None,
+) -> None:
+    """Upsert records into a table.
+
+    This function performs an upsert (update/insert) operation by:
+    1. Creating a temporary table with the new records
+    2. Deleting matching records from target table based on key_field
+    3. Inserting the new records into target table
+    4. Cleaning up temporary table
+
+    Args:
+        dataset: dataset name.
+        table: table name.
+        records: records to be upserted.
+        key_field: field used to match records for update.
+        json_key: json key with gcp credentials.
+        insert_chunk_size: chunk size for batch inserts.
+        client: client to connect to BigQuery.
+
+    Raises:
+        BigQuerySchemaMismatchException: if schema of new records doesn't match table.
+        BigQueryClientException: if schema cannot be inferred from records.
+    """
+    client = client or BigQueryClient(json_key=json_key or {})
+
+    if not records:
+        logger.warning("No records to create a table from! (empty collection given)")
+        return
+
+    data_schema_json = _create_schema_from_records(records=records or [])
+    data_schema_bq = [
+        bigquery.SchemaField.from_api_repr(field) for field in data_schema_json
+    ]
+
+    table_schema_bq = client.get_table(dataset, table).schema
+
+    if table_schema_bq != data_schema_bq:
+        raise BigQuerySchemaMismatchException(
+            message="New data schema does not match table schema",
+            source_schema=table_schema_bq,
+            target_schema=data_schema_bq,
+        )
+
+    # set up tmp table
+    tmp_table = table + "_tmp"
+    delete_table(dataset=dataset, table=tmp_table, client=client)
+    create_table(
+        dataset=dataset, table=tmp_table, schema=data_schema_json, client=client
+    )
+    insert(
+        dataset=dataset,
+        table=tmp_table,
+        records=records,
+        client=client,
+        chunk_size=insert_chunk_size,
+    )
+
+    # delete records from target table
+    command_sql = (
+        f"delete from {dataset}.{table} "
+        f"where {key_field} in (select {key_field} from {dataset}.{tmp_table})"
+    )
+
+    logger.info(f"Running `{command_sql}`...")
+    client.run_command(command_sql=command_sql)
+    logger.info("Command executed!")
+
+    # insert records into target table
+    insert(
+        dataset=dataset,
+        table=table,
+        records=records,
+        client=client,
+        chunk_size=insert_chunk_size,
+    )
+
+    # clean up temporary table
+    delete_table(dataset=dataset, table=tmp_table, client=client)
 
 
 def replace_table(

--- a/gcpde/bq.py
+++ b/gcpde/bq.py
@@ -194,7 +194,7 @@ class BigQuerySchemaMismatchException(Exception):
         self.source_schema = source_schema
         self.target_schema = target_schema
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"{self.message}\n"
             f"Source schema: {self.source_schema}\n"

--- a/tests/unit/test_bq.py
+++ b/tests/unit/test_bq.py
@@ -1,8 +1,9 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
 from google.api_core.exceptions import NotFound
+from google.cloud.bigquery import DatasetReference, SchemaField, TableReference
 
 from gcpde import bq
 
@@ -86,6 +87,18 @@ class TestBigQueryClient:
 
         # assert
         bq_client.client.query.assert_called_once_with(command)
+
+    def test_get_table(self, bq_client: bq.BigQueryClient):
+        # arrange
+        dataset_ref = DatasetReference(bq_client.client.project, self.dataset)
+        expected_table_ref = TableReference(dataset_ref, self.table)
+
+        # act
+        result = bq_client.get_table(dataset=self.dataset, table=self.table)
+
+        # assert
+        bq_client.client.get_table.assert_called_once_with(table=expected_table_ref)
+        assert result is not None
 
 
 def test_create_table_from_records():
@@ -283,3 +296,127 @@ def test_create_table_from_query():
         command_sql="create or replace table dataset.table as select * from table",
         timeout=10,
     )
+
+
+@patch("gcpde.bq.delete_table")
+@patch("gcpde.bq.create_table")
+@patch("gcpde.bq.insert")
+def test_upsert_table_from_records(mock_insert, mock_create_table, mock_delete_table):
+    # arrange
+    mock_client = Mock(spec_set=bq.BigQueryClient)
+    table_tmp = "table_tmp"
+    table = "table"
+    dataset = "dataset"
+
+    table_mock = Mock(schema=[])
+    mock_client.get_table.return_value = table_mock
+
+    schema_json = [{"name": "id", "type": "INTEGER", "mode": "NULLABLE"}]
+    table_mock.schema = [SchemaField.from_api_repr(field) for field in schema_json]
+
+    command_sql = (
+        "delete from dataset.table where id in (select id from dataset.table_tmp)"
+    )
+
+    # act
+    bq.upsert_table_from_records(
+        dataset=dataset,
+        table=table,
+        records=[{"id": 1}],
+        key_field="id",
+        client=mock_client,
+        insert_chunk_size=None,
+    )
+
+    # assert
+
+    mock_delete_table.assert_called_with(
+        dataset=dataset, table=table_tmp, client=mock_client
+    )
+
+    mock_create_table.assert_called_once_with(
+        dataset=dataset,
+        table=table_tmp,
+        schema=schema_json,
+        client=mock_client,
+    )
+    mock_insert.assert_any_call(
+        dataset=dataset,
+        table=table_tmp,
+        records=[{"id": 1}],
+        client=mock_client,
+        chunk_size=None,
+    )
+
+    # assert that the delete was right set
+    mock_client.run_command.assert_called_with(command_sql=command_sql)
+
+    mock_insert.assert_any_call(
+        dataset=dataset,
+        table=table,
+        records=[{"id": 1}],
+        client=mock_client,
+        chunk_size=None,
+    )
+
+    # Assert that delete_table was not called with the main table name
+    for call in mock_delete_table.call_args_list:
+        assert call.kwargs.get("table") != table
+
+    # cleanup was done
+    assert mock_delete_table.call_count == 2
+
+    # make sure only one insert was done to each table, we checked each call
+    assert mock_insert.call_count == 2
+
+
+def test_upsert_table_from_records_no_records():
+    # arrange
+    mock_client = Mock(spec_set=bq.BigQueryClient)
+
+    # act
+    bq.upsert_table_from_records(
+        dataset="dataset", table="table", records=[], key_field="id", client=mock_client
+    )
+
+    # assert
+    mock_client.run_command.assert_not_called()
+    mock_client.delete_table.assert_not_called()
+    mock_client.create_table.assert_not_called()
+
+
+def test_upsert_table_from_records_schema_mismatch():
+    # arrange
+    mock_client = Mock(spec_set=bq.BigQueryClient)
+
+    table_mock = Mock(schema=[])
+    mock_client.get_table.return_value = table_mock
+
+    schema_json = [{"name": "uuid", "type": "STRING", "mode": "NULLABLE"}]
+    table_mock.schema = [SchemaField.from_api_repr(field) for field in schema_json]
+
+    # act
+    with pytest.raises(bq.BigQuerySchemaMismatchException):
+        bq.upsert_table_from_records(
+            dataset="dataset",
+            table="table",
+            records=[{"id": 1}],
+            key_field="id",
+            client=mock_client,
+        )
+
+    # assert
+    mock_client.run_command.assert_not_called()
+    mock_client.delete_table.assert_not_called()
+    mock_client.create_table.assert_not_called()
+
+def test_big_query_schema_mismatch_exception():
+    # arrange
+    source_schema = [{"name": "id"}]
+    target_schema = [{"name": "id"}]
+
+    # act
+    exception = bq.BigQuerySchemaMismatchException(message="message", source_schema=source_schema, target_schema=target_schema)
+
+    # assert
+    assert str(exception) == "message\nSource schema: [{'name': 'id'}]\nTarget schema: [{'name': 'id'}]"

--- a/tests/unit/test_bq.py
+++ b/tests/unit/test_bq.py
@@ -410,13 +410,19 @@ def test_upsert_table_from_records_schema_mismatch():
     mock_client.delete_table.assert_not_called()
     mock_client.create_table.assert_not_called()
 
+
 def test_big_query_schema_mismatch_exception():
     # arrange
     source_schema = [{"name": "id"}]
     target_schema = [{"name": "id"}]
 
     # act
-    exception = bq.BigQuerySchemaMismatchException(message="message", source_schema=source_schema, target_schema=target_schema)
+    exception = bq.BigQuerySchemaMismatchException(
+        message="message", source_schema=source_schema, target_schema=target_schema
+    )
 
     # assert
-    assert str(exception) == "message\nSource schema: [{'name': 'id'}]\nTarget schema: [{'name': 'id'}]"
+    assert (
+        str(exception)
+        == "message\nSource schema: [{'name': 'id'}]\nTarget schema: [{'name': 'id'}]"
+    )


### PR DESCRIPTION
This PR creates the upsert feature thata works with the merge statement

workflow:
1. create tmp table (overwrite)
2. use merge statement to upsert
3. cleanup tmp table

Notes:
If the target table schema doesn't match to the new data, an exception in raised (A newly created one).