### PR TITLE
:construction_worker: add Release job for bumping version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Check out Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         enable-cache: true
         cache-suffix: "optional-suffix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Bump version
+        run: uv version "${GITHUB_REF_NAME#v}"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "🔖 bump version to ${GITHUB_REF_NAME#v} [skip ci]"
+          git push origin main


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an automated release workflow that pushes commits directly to `main` with `contents: write`, which can affect versioning/history if misconfigured. Also updates GitHub Actions dependencies, which is low risk but impacts CI execution.
> 
> **Overview**
> Updates the main CI workflow to use `actions/checkout@v6` and pins `astral-sh/setup-uv` to the v8.0.0 commit for reproducible builds.
> 
> Adds a new `Release` workflow that runs on `release.published`, bumps the project version via `uv version` from the tag name, then commits and pushes the updated `pyproject.toml` and `uv.lock` back to `main` (with `[skip ci]`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03ced35d440067eca052ece35a214edbfa511436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->