### PR TITLE
🐛 fix gcs shallow search

### DIFF
--- a/gcpde/gcs.py
+++ b/gcpde/gcs.py
@@ -379,7 +379,7 @@ async def _async_list_files(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
-    recursive: bool = True,
+    recursive: bool = False,
 ) -> List[str]:
     extra_api_params = api_params or {}
     items = []
@@ -430,7 +430,7 @@ async def _async_list_files_handling_auth(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
-    recursive: bool = True,
+    recursive: bool = False,
 ) -> List[str]:
     _check_auth_args(json_key=json_key, credentials=credentials, client=client)
     session_timeout = ClientTimeout(total=None, sock_connect=timeout, sock_read=timeout)
@@ -459,7 +459,7 @@ def list_files(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
-    recursive: bool = True,
+    recursive: bool = False,
 ) -> List[str]:
     """List files on gcs from a given prefix.
 
@@ -473,8 +473,8 @@ def list_files(
         api_params: parameters for the API request (ref. https://cloud.google.com/storage/docs/json_api/v1/objects/list).
         updated_after: filter files updated after this datetime.
         updated_before: filter files updated before this datetime.
-        recursive: if True (default), list all objects under the prefix
-            recursively. If False, use delimiter='/' for a shallow
+        recursive: if True, list all objects under the prefix recursively.
+            If False (default), use delimiter='/' for a shallow
             single-level listing.
     """
     logger.info(f"Listing files from {prefix} on {bucket_name} bucket...")

--- a/gcpde/gcs.py
+++ b/gcpde/gcs.py
@@ -379,12 +379,15 @@ async def _async_list_files(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
+    recursive: bool = True,
 ) -> List[str]:
     extra_api_params = api_params or {}
     items = []
     next_page_token = None
     while True:
-        params = {"prefix": prefix, "delimiter": "/", **extra_api_params}
+        params: dict[str, Any] = {"prefix": prefix, **extra_api_params}
+        if not recursive:
+            params.setdefault("delimiter", "/")
         if next_page_token:
             params["pageToken"] = next_page_token
 
@@ -392,7 +395,7 @@ async def _async_list_files(
             bucket=bucket_name,
             params=params,
         )
-        items.extend(search_result["items"])
+        items.extend(search_result.get("items", []))
         next_page_token = search_result.get("nextPageToken")
 
         if not next_page_token:
@@ -427,6 +430,7 @@ async def _async_list_files_handling_auth(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
+    recursive: bool = True,
 ) -> List[str]:
     _check_auth_args(json_key=json_key, credentials=credentials, client=client)
     session_timeout = ClientTimeout(total=None, sock_connect=timeout, sock_read=timeout)
@@ -441,6 +445,7 @@ async def _async_list_files_handling_auth(
             api_params=api_params,
             updated_after=updated_after,
             updated_before=updated_before,
+            recursive=recursive,
         )
 
 
@@ -454,6 +459,7 @@ def list_files(
     api_params: Optional[Dict[str, Any]] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
+    recursive: bool = True,
 ) -> List[str]:
     """List files on gcs from a given prefix.
 
@@ -467,6 +473,9 @@ def list_files(
         api_params: parameters for the API request (ref. https://cloud.google.com/storage/docs/json_api/v1/objects/list).
         updated_after: filter files updated after this datetime.
         updated_before: filter files updated before this datetime.
+        recursive: if True (default), list all objects under the prefix
+            recursively. If False, use delimiter='/' for a shallow
+            single-level listing.
     """
     logger.info(f"Listing files from {prefix} on {bucket_name} bucket...")
     file_paths = asyncio.run(
@@ -480,6 +489,7 @@ def list_files(
             api_params=api_params,
             updated_after=updated_after,
             updated_before=updated_before,
+            recursive=recursive,
         )
     )
     logger.info(f"{len(file_paths)} files found.")

--- a/tests/unit/test_gcs.py
+++ b/tests/unit/test_gcs.py
@@ -302,7 +302,7 @@ def test_list_files(mock__async_list_files: mock.AsyncMock):
 @pytest.mark.asyncio
 @mock.patch("gcpde.gcs.AsyncStorageClient", autospec=True)
 async def test__async_list_files_recursive(mock_client: mock.Mock):
-    """Default recursive=True should NOT send a delimiter param."""
+    """recursive=True should NOT send a delimiter param."""
     mock_client.list_objects.return_value = {
         "items": [
             {"name": "prefix/a/file1.jsonl"},
@@ -314,6 +314,7 @@ async def test__async_list_files_recursive(mock_client: mock.Mock):
         bucket_name="my-bucket",
         prefix="prefix/",
         client=mock_client,
+        recursive=True,
     )
 
     assert output == ["prefix/a/file1.jsonl", "prefix/b/file2.jsonl"]

--- a/tests/unit/test_gcs.py
+++ b/tests/unit/test_gcs.py
@@ -299,6 +299,69 @@ def test_list_files(mock__async_list_files: mock.AsyncMock):
     ]
 
 
+@pytest.mark.asyncio
+@mock.patch("gcpde.gcs.AsyncStorageClient", autospec=True)
+async def test__async_list_files_recursive(mock_client: mock.Mock):
+    """Default recursive=True should NOT send a delimiter param."""
+    mock_client.list_objects.return_value = {
+        "items": [
+            {"name": "prefix/a/file1.jsonl"},
+            {"name": "prefix/b/file2.jsonl"},
+        ]
+    }
+
+    output = await gcs._async_list_files(
+        bucket_name="my-bucket",
+        prefix="prefix/",
+        client=mock_client,
+    )
+
+    assert output == ["prefix/a/file1.jsonl", "prefix/b/file2.jsonl"]
+    called_params = mock_client.list_objects.call_args.kwargs["params"]
+    assert "delimiter" not in called_params
+
+
+@pytest.mark.asyncio
+@mock.patch("gcpde.gcs.AsyncStorageClient", autospec=True)
+async def test__async_list_files_shallow(mock_client: mock.Mock):
+    """recursive=False should set delimiter='/' for a shallow listing."""
+    mock_client.list_objects.return_value = {
+        "items": [
+            {"name": "prefix/file_at_root.jsonl"},
+        ],
+        "prefixes": ["prefix/subdir/"],
+    }
+
+    output = await gcs._async_list_files(
+        bucket_name="my-bucket",
+        prefix="prefix/",
+        client=mock_client,
+        recursive=False,
+    )
+
+    assert output == ["prefix/file_at_root.jsonl"]
+    called_params = mock_client.list_objects.call_args.kwargs["params"]
+    assert called_params["delimiter"] == "/"
+
+
+@pytest.mark.asyncio
+@mock.patch("gcpde.gcs.AsyncStorageClient", autospec=True)
+async def test__async_list_files_shallow_prefixes_only(mock_client: mock.Mock):
+    """Shallow listing where the response has only prefixes and no 'items' key."""
+    mock_client.list_objects.return_value = {
+        "prefixes": ["prefix/subdir_a/", "prefix/subdir_b/"],
+    }
+
+    output = await gcs._async_list_files(
+        bucket_name="my-bucket",
+        prefix="prefix/",
+        client=mock_client,
+        recursive=False,
+    )
+
+    assert output == []
+
+
 def test__check_auth_args_exception():
     # arrange
     json_key = None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches GCS listing behavior (delimiter handling and response parsing), which can change which objects callers see; risk is moderate but scoped and covered by new unit tests.
> 
> **Overview**
> `list_files` (and underlying async helpers) now supports a `recursive` flag to control whether GCS listings are *shallow* (default, using `delimiter='/'`) or *recursive* (no delimiter).
> 
> The listing implementation is hardened to handle responses that omit the `items` key (e.g., when only `prefixes` are returned), and new unit tests cover recursive vs shallow parameter behavior and the prefix-only edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f902e4d0eade621d2e14905306d60451d253fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->