### PR TITLE
Add merge-friendly Kindex project graph

### DIFF
--- a/.kin/.gitignore
+++ b/.kin/.gitignore
@@ -1,0 +1,7 @@
+/local/
+/cache/
+/tmp/
+/private/
+*.db
+*.sqlite
+*.sqlite3

--- a/.kin/code-map.json
+++ b/.kin/code-map.json
@@ -1,0 +1,326 @@
+{
+  "edges": [
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-1e8ae2608ffc",
+      "target": "code-mod-gcpde-6e26ab0af1f3",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-38807bca64e5",
+      "target": "code-mod-gcpde-6e26ab0af1f3",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-3bae1c7ff39c",
+      "target": "code-mod-gcpde-3570eda60ec1",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-8250ce12a046",
+      "target": "code-mod-gcpde-6e26ab0af1f3",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-927676d0db65",
+      "target": "code-mod-gcpde-3570eda60ec1",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-bb31c7cd5ff8",
+      "target": "code-mod-gcpde-3570eda60ec1",
+      "type": "contains",
+      "weight": 0.6
+    },
+    {
+      "direction": "outbound",
+      "source": "code-sym-gcpde-dfeff2fff8bd",
+      "target": "code-mod-gcpde-3570eda60ec1",
+      "type": "contains",
+      "weight": 0.6
+    }
+  ],
+  "layers": [
+    {
+      "description": "Kindex-inferred core layer.",
+      "id": "core",
+      "name": "Core",
+      "nodeIds": [
+        "code-mod-gcpde-3570eda60ec1",
+        "code-mod-gcpde-62f047bea506",
+        "code-mod-gcpde-672c10164972",
+        "code-mod-gcpde-69f6a9b7087a",
+        "code-mod-gcpde-6e26ab0af1f3"
+      ]
+    },
+    {
+      "description": "Kindex-inferred domain layer.",
+      "id": "domain",
+      "name": "Domain",
+      "nodeIds": [
+        "code-sym-gcpde-1e8ae2608ffc",
+        "code-sym-gcpde-38807bca64e5",
+        "code-sym-gcpde-3bae1c7ff39c",
+        "code-sym-gcpde-8250ce12a046",
+        "code-sym-gcpde-927676d0db65",
+        "code-sym-gcpde-bb31c7cd5ff8",
+        "code-sym-gcpde-dfeff2fff8bd"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "complexity": 1,
+      "filePath": "gcpde/base.py",
+      "id": "code-mod-gcpde-62f047bea506",
+      "languageNotes": {
+        "kindexType": "artifact",
+        "language": "Python",
+        "toolTier": "C"
+      },
+      "name": "gcpde/base.py",
+      "summary": "Language: Python | Path: gcpde/base.py | ~6 lines ## Functions - get_utc_now() -> datetime.datetime",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "file"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/bq.py",
+      "id": "code-sym-gcpde-1e8ae2608ffc",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "BigQuerySchemaMismatchException",
+      "summary": "class BigQuerySchemaMismatchException(Exception) (gcpde/bq.py:241) ## Methods - __str__(self) -> str",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/bq.py",
+      "id": "code-sym-gcpde-38807bca64e5",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "BigQueryClientException",
+      "summary": "class BigQueryClientException(Exception) (gcpde/bq.py:237)",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 8,
+      "filePath": "gcpde/bq.py",
+      "id": "code-sym-gcpde-8250ce12a046",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "BigQueryClient",
+      "summary": "class BigQueryClient (gcpde/bq.py:24) ## Methods - check_table(self, dataset: str, table: str) -> bool",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 17,
+      "filePath": "gcpde/bq.py",
+      "id": "code-mod-gcpde-6e26ab0af1f3",
+      "languageNotes": {
+        "kindexType": "artifact",
+        "language": "Python",
+        "toolTier": "C"
+      },
+      "name": "gcpde/bq.py",
+      "summary": "Language: Python | Path: gcpde/bq.py | ~736 lines ## Classes - BigQueryClient",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "file"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/gcs.py",
+      "id": "code-sym-gcpde-3bae1c7ff39c",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "GCSDownloadedFile",
+      "summary": "class GCSDownloadedFile(BaseModel) (gcpde/gcs.py:24)",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/gcs.py",
+      "id": "code-sym-gcpde-927676d0db65",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "DateTimePartitions",
+      "summary": "class DateTimePartitions(BaseModel) (gcpde/gcs.py:42) ## Methods - __str__(self) -> str",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/gcs.py",
+      "id": "code-sym-gcpde-bb31c7cd5ff8",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "BuildFileNameProtocol",
+      "summary": "class BuildFileNameProtocol(Protocol) (gcpde/gcs.py:70) ## Methods - __call__(self, *args: Any, **kwargs: Any) -> str",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/gcs.py",
+      "id": "code-sym-gcpde-dfeff2fff8bd",
+      "languageNotes": {
+        "kindexType": "concept",
+        "language": "Python",
+        "toolTier": ""
+      },
+      "name": "GCSHMACKeyConfig",
+      "summary": "class GCSHMACKeyConfig(BaseModel) (gcpde/gcs.py:31)",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "class"
+    },
+    {
+      "complexity": 27,
+      "filePath": "gcpde/gcs.py",
+      "id": "code-mod-gcpde-3570eda60ec1",
+      "languageNotes": {
+        "kindexType": "artifact",
+        "language": "Python",
+        "toolTier": "C"
+      },
+      "name": "gcpde/gcs.py",
+      "summary": "Language: Python | Path: gcpde/gcs.py | ~600 lines ## Classes - BuildFileNameProtocol(Protocol)",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "file"
+    },
+    {
+      "complexity": 6,
+      "filePath": "gcpde/sheets.py",
+      "id": "code-mod-gcpde-69f6a9b7087a",
+      "languageNotes": {
+        "kindexType": "artifact",
+        "language": "Python",
+        "toolTier": "C"
+      },
+      "name": "gcpde/sheets.py",
+      "summary": "Language: Python | Path: gcpde/sheets.py | ~159 lines ## Functions - read_sheet( document_id: str, sheet_name: str, json_key: Optional[dict[str, str]] = None, head: int = 1, expected_headers: Optional[list[str]] = None, credentials: Optional[GoogleCredentials] = None, ) -> list[dict[str,str|None]]",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "file"
+    },
+    {
+      "complexity": 1,
+      "filePath": "gcpde/types.py",
+      "id": "code-mod-gcpde-672c10164972",
+      "languageNotes": {
+        "kindexType": "artifact",
+        "language": "Python",
+        "toolTier": "C"
+      },
+      "name": "gcpde/types.py",
+      "summary": "Language: Python | Path: gcpde/types.py | ~11 lines",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "type": "file"
+    }
+  ],
+  "project": {
+    "analyzedAt": "2026-04-15T19:08:30Z",
+    "description": "Code map exported from Kindex for gcpde.",
+    "frameworks": [],
+    "gitCommitHash": "a1805787cbaf728e9ff9676e429880c82e5dd0ea",
+    "languages": [
+      "Python"
+    ],
+    "name": "gcpde"
+  },
+  "tour": [
+    {
+      "description": "Review 5 node(s) in the Core layer.",
+      "nodeIds": [
+        "code-mod-gcpde-3570eda60ec1",
+        "code-mod-gcpde-62f047bea506",
+        "code-mod-gcpde-672c10164972",
+        "code-mod-gcpde-69f6a9b7087a",
+        "code-mod-gcpde-6e26ab0af1f3"
+      ],
+      "order": 1,
+      "title": "Core"
+    },
+    {
+      "description": "Review 7 node(s) in the Domain layer.",
+      "nodeIds": [
+        "code-sym-gcpde-1e8ae2608ffc",
+        "code-sym-gcpde-38807bca64e5",
+        "code-sym-gcpde-3bae1c7ff39c",
+        "code-sym-gcpde-8250ce12a046",
+        "code-sym-gcpde-927676d0db65",
+        "code-sym-gcpde-bb31c7cd5ff8",
+        "code-sym-gcpde-dfeff2fff8bd"
+      ],
+      "order": 2,
+      "title": "Domain"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/.kin/config
+++ b/.kin/config
@@ -1,0 +1,16 @@
+name: gcpde
+audience: team
+domains:
+  - wander
+  - gcpde
+
+work_policy:
+  require_active_tag: false
+  linear:
+    enabled: false
+    require_issue: false
+  git:
+    block_commit_without_tag: false
+    block_commit_without_linear: false
+    block_push_without_tag: false
+    block_push_without_linear: false

--- a/.kin/index.json
+++ b/.kin/index.json
@@ -1,0 +1,144 @@
+{
+  "domains": [
+    "code",
+    "python"
+  ],
+  "node_count": 12,
+  "nodes": [
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-mod-gcpde-3570eda60ec1",
+      "title": "gcpde/gcs.py",
+      "type": "artifact",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-mod-gcpde-62f047bea506",
+      "title": "gcpde/base.py",
+      "type": "artifact",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-mod-gcpde-672c10164972",
+      "title": "gcpde/types.py",
+      "type": "artifact",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-mod-gcpde-69f6a9b7087a",
+      "title": "gcpde/sheets.py",
+      "type": "artifact",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-mod-gcpde-6e26ab0af1f3",
+      "title": "gcpde/bq.py",
+      "type": "artifact",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-1e8ae2608ffc",
+      "title": "BigQuerySchemaMismatchException",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-38807bca64e5",
+      "title": "BigQueryClientException",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-3bae1c7ff39c",
+      "title": "GCSDownloadedFile",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-8250ce12a046",
+      "title": "BigQueryClient",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-927676d0db65",
+      "title": "DateTimePartitions",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-bb31c7cd5ff8",
+      "title": "BuildFileNameProtocol",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-gcpde-dfeff2fff8bd",
+      "title": "GCSHMACKeyConfig",
+      "type": "concept",
+      "updated_at": "2026-05-30T14:52:09",
+      "weight": 0.5
+    }
+  ],
+  "repo": "gcpde",
+  "source_updated_at": "2026-05-30T14:52:09",
+  "version": 1
+}


### PR DESCRIPTION
Adds the committed Kindex project graph artifacts for this repository.

Included artifacts:
- `.kin/config`
- `.kin/.gitignore` for local/cache/private Kindex state
- `.kin/code-map.json`
- `.kin/index.json`

Generated from `origin/main` with Kindex 0.21.3. The branch stages only `.kin` files plus root `.gitignore` when needed to keep those artifacts unignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only additions with no changes to application logic, auth, or data paths; main risk is merge noise or stale graph if not regenerated after large refactors.
> 
> **Overview**
> This PR **introduces a committed Kindex (`.kin`) project graph** for the `gcpde` repo so tooling can use a versioned, merge-friendly view of the codebase without relying on local-only index state.
> 
> It adds **`.kin/config`** (project name, team audience, `wander`/`gcpde` domains, and permissive work/git policies with Linear and tag gates disabled), **`.kin/index.json`** (12 indexed nodes for Python modules and key symbols under `gcpde/`), and **`.kin/code-map.json`** (layered graph with core vs domain nodes, `contains` edges from symbols to files, and a guided tour). **`.kin/.gitignore`** keeps local/cache/private paths and SQLite artifacts out of git.
> 
> There are **no runtime or application code changes** in this diff—only generated/metadata artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b31c4cf34f55e97b6a0192be118aee82aefd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->