### PR TITLE
✨ add replace_or_create_from_records,  list_worksheets, delete_worksheet

### DIFF
--- a/gcpde/sheets.py
+++ b/gcpde/sheets.py
@@ -1,11 +1,12 @@
 """Google Sheets client."""
 
-from typing import Optional
+from typing import Any, Optional
 
 import gspread
 from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.credentials import Scoped
 from gspread import Spreadsheet, Worksheet
+from gspread.exceptions import WorksheetNotFound
 from loguru import logger
 
 from gcpde.types import ListJsonType
@@ -114,6 +115,102 @@ def replace_from_records(
     records_as_row = [[r[c] for c in columns] for r in records]
     sheet.update(values=[columns] + records_as_row, range_name="A1")
     logger.info("Document update finished!")
+
+
+def replace_or_create_from_records(
+    document_id: str,
+    sheet_name: str,
+    records: list[dict[str, Any]],
+    columns: list[str],
+    min_rows: int = 100,
+    json_key: dict[str, str] | None = None,
+    credentials: GoogleCredentials | None = None,
+) -> Worksheet:
+    """Replace worksheet content, creating and resizing the worksheet as needed.
+
+    Args:
+        document_id: ID for the document (can be retrieved from the URL).
+        sheet_name: Name of the worksheet to replace or create.
+        records: Records to write to the worksheet.
+        columns: Column names and order to use when writing records.
+        min_rows: Minimum number of rows the worksheet should contain.
+        json_key: JSON key with GCP credentials.
+        credentials: Google-auth credentials to connect to GCP.
+
+    Returns:
+        The created or updated worksheet.
+    """
+    logger.info(f"Document '{document_id}' update started ...")
+    spreadsheet = _open_document(
+        document_id=document_id, json_key=json_key, credentials=credentials
+    )
+    required_rows = len(records) + 1
+
+    try:
+        worksheet = spreadsheet.worksheet(sheet_name)
+    except WorksheetNotFound:
+        worksheet = spreadsheet.add_worksheet(
+            title=sheet_name,
+            rows=max(min_rows, required_rows),
+            cols=len(columns),
+        )
+
+    worksheet.resize(
+        rows=max(worksheet.row_count, min_rows, required_rows),
+        cols=max(worksheet.col_count, len(columns)),
+    )
+    worksheet.clear()
+    worksheet.update(
+        values=[columns]
+        + [[record[column] for column in columns] for record in records],
+        range_name="A1",
+    )
+    logger.info("Document update finished!")
+    return worksheet
+
+
+def list_worksheets(
+    document_id: str,
+    json_key: dict[str, str] | None = None,
+    credentials: GoogleCredentials | None = None,
+) -> list[Worksheet]:
+    """List all worksheets in a Google Sheets document.
+
+    Args:
+        document_id: ID for the document (can be retrieved from the URL).
+        json_key: JSON key with GCP credentials.
+        credentials: Google-auth credentials to connect to GCP.
+
+    Returns:
+        All worksheets in the document.
+    """
+    spreadsheet = _open_document(
+        document_id=document_id, json_key=json_key, credentials=credentials
+    )
+    return spreadsheet.worksheets()
+
+
+def delete_worksheet(
+    document_id: str,
+    sheet_name: str,
+    json_key: dict[str, str] | None = None,
+    credentials: GoogleCredentials | None = None,
+) -> None:
+    """Delete a worksheet from a Google Sheets document.
+
+    Args:
+        document_id: ID for the document (can be retrieved from the URL).
+        sheet_name: Name of the worksheet to delete.
+        json_key: JSON key with GCP credentials.
+        credentials: Google-auth credentials to connect to GCP.
+
+    Raises:
+        gspread.exceptions.WorksheetNotFound: If the worksheet does not exist.
+    """
+    spreadsheet = _open_document(
+        document_id=document_id, json_key=json_key, credentials=credentials
+    )
+    spreadsheet.del_worksheet(spreadsheet.worksheet(sheet_name))
 
 
 def read_sheet(

--- a/gcpde/sheets.py
+++ b/gcpde/sheets.py
@@ -1,6 +1,6 @@
 """Google Sheets client."""
 
-from typing import Any, Optional
+from typing import Optional
 
 import gspread
 from google.auth.credentials import Credentials as GoogleCredentials
@@ -120,7 +120,7 @@ def replace_from_records(
 def replace_or_create_from_records(
     document_id: str,
     sheet_name: str,
-    records: list[dict[str, Any]],
+    records: ListJsonType,
     columns: list[str],
     min_rows: int = 100,
     json_key: dict[str, str] | None = None,
@@ -154,11 +154,11 @@ def replace_or_create_from_records(
             rows=max(min_rows, required_rows),
             cols=len(columns),
         )
-
-    worksheet.resize(
-        rows=max(worksheet.row_count, min_rows, required_rows),
-        cols=max(worksheet.col_count, len(columns)),
-    )
+    else:
+        worksheet.resize(
+            rows=max(worksheet.row_count, min_rows, required_rows),
+            cols=max(worksheet.col_count, len(columns)),
+        )
     worksheet.clear()
     worksheet.update(
         values=[columns]

--- a/tests/unit/test_sheets.py
+++ b/tests/unit/test_sheets.py
@@ -129,7 +129,7 @@ def test_replace_or_create_from_records_creates_missing_worksheet(
     mock_spreadsheet.add_worksheet.assert_called_once_with(
         title="2026-07-20", rows=10, cols=2
     )
-    mock_worksheet.resize.assert_called_once_with(rows=100, cols=2)
+    mock_worksheet.resize.assert_not_called()
     mock_worksheet.clear.assert_called_once()
     assert mock_worksheet.update.call_args.kwargs == {
         "values": [["date", "count"], ["2026-07-20", 1]],

--- a/tests/unit/test_sheets.py
+++ b/tests/unit/test_sheets.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from google.auth.credentials import Scoped
+from gspread.exceptions import WorksheetNotFound
 
 from gcpde import sheets
 
@@ -9,6 +10,14 @@ MockWorksheet = mock.Mock("gspread.worksheet.Worksheet", autospec=True)
 MockSpreadsheet = mock.Mock("gspread.spreadsheet.Spreadsheet", autospec=True)
 
 MOCK_JSON_KEY = {"type": "service_account"}
+
+
+def _mock_spreadsheet() -> mock.Mock:
+    return mock.create_autospec(sheets.Spreadsheet, instance=True)
+
+
+def _mock_worksheet() -> mock.Mock:
+    return mock.create_autospec(sheets.Worksheet, instance=True)
 
 
 @mock.patch("gspread.service_account_from_dict", autospec=True)
@@ -88,6 +97,87 @@ def test_replace_from_records(mock_open_sheet: mock.Mock):
     kwargs = mock_worksheet.update.call_args.kwargs
     assert list(kwargs["values"]) == [["col"], ["value"]]
     assert kwargs["range_name"] == "A1"
+
+
+@mock.patch("gcpde.sheets._open_document", autospec=True)
+def test_replace_or_create_from_records_creates_missing_worksheet(
+    mock_open_document: mock.Mock,
+):
+    # arrange
+    mock_spreadsheet = _mock_spreadsheet()
+    mock_open_document.return_value = mock_spreadsheet
+    mock_spreadsheet.worksheet.side_effect = WorksheetNotFound
+    mock_worksheet = _mock_worksheet()
+    mock_worksheet.row_count = 100
+    mock_worksheet.col_count = 2
+    mock_worksheet.url = (
+        "https://docs.google.com/spreadsheets/d/document_id/edit#gid=123"
+    )
+    mock_spreadsheet.add_worksheet.return_value = mock_worksheet
+
+    # act
+    result = sheets.replace_or_create_from_records(
+        document_id="document_id",
+        sheet_name="2026-07-20",
+        records=[{"date": "2026-07-20", "count": 1}],
+        columns=["date", "count"],
+        min_rows=10,
+        json_key=MOCK_JSON_KEY,
+    )
+
+    # assert
+    mock_spreadsheet.add_worksheet.assert_called_once_with(
+        title="2026-07-20", rows=10, cols=2
+    )
+    mock_worksheet.resize.assert_called_once_with(rows=100, cols=2)
+    mock_worksheet.clear.assert_called_once()
+    assert mock_worksheet.update.call_args.kwargs == {
+        "values": [["date", "count"], ["2026-07-20", 1]],
+        "range_name": "A1",
+    }
+    assert result is mock_worksheet
+    assert result.url.endswith("#gid=123")
+
+
+@mock.patch("gcpde.sheets._open_document", autospec=True)
+def test_list_worksheets_uses_authenticated_document(mock_open_document: mock.Mock):
+    # arrange
+    mock_spreadsheet = _mock_spreadsheet()
+    mock_open_document.return_value = mock_spreadsheet
+    worksheets = [_mock_worksheet(), _mock_worksheet()]
+    mock_spreadsheet.worksheets.return_value = worksheets
+    credentials = mock.MagicMock(spec=Scoped)
+
+    # act
+    result = sheets.list_worksheets(document_id="document_id", credentials=credentials)
+
+    # assert
+    mock_open_document.assert_called_once_with(
+        document_id="document_id", json_key=None, credentials=credentials
+    )
+    assert result == worksheets
+
+
+@mock.patch("gcpde.sheets._open_document", autospec=True)
+def test_delete_worksheet_uses_authenticated_document(mock_open_document: mock.Mock):
+    # arrange
+    mock_spreadsheet = _mock_spreadsheet()
+    mock_open_document.return_value = mock_spreadsheet
+    worksheet = _mock_worksheet()
+    mock_spreadsheet.worksheet.return_value = worksheet
+
+    # act
+    sheets.delete_worksheet(
+        document_id="document_id",
+        sheet_name="sheet_name",
+        json_key=MOCK_JSON_KEY,
+    )
+
+    # assert
+    mock_open_document.assert_called_once_with(
+        document_id="document_id", json_key=MOCK_JSON_KEY, credentials=None
+    )
+    mock_spreadsheet.del_worksheet.assert_called_once_with(worksheet)
 
 
 @mock.patch("gcpde.sheets._open_sheet", autospec=True)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API and tests only; `delete_worksheet` can remove remote tabs but behavior is explicit and documented.
> 
> **Overview**
> Extends the Google Sheets client with **worksheet lifecycle** operations beyond the existing `replace_from_records` path (which still requires the tab to exist).
> 
> **`replace_or_create_from_records`** opens the spreadsheet, creates the named worksheet when `WorksheetNotFound` is raised (sized with `min_rows` and data length), otherwise resizes rows/cols as needed, then clears and writes header + records like `replace_from_records`—and returns the `Worksheet` (e.g. for its URL).
> 
> **`list_worksheets`** returns all `Worksheet` objects for a document via `_open_document`. **`delete_worksheet`** resolves the tab by name and calls `del_worksheet` (missing names still surface `WorksheetNotFound`).
> 
> Unit tests add shared spreadsheet/worksheet mocks and cover create-on-miss, list, and delete wiring through `_open_document`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ad6346dec998a0788a2eef61f54329012fc1b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->